### PR TITLE
Update links pointing to OpenQuake

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,16 +44,16 @@ OQ Hazard Library
 One of the significant factors driving the rewrite of ShakeMap into the Python
 language was the availability of the library of Ground Motion Prediction
 Equations (GMPEs) and other tools incorporated into the OpenQuake (OQ_)
-hazard library (oq-hazardlib_).
+Hazard Library (openquake.hazardlib_).
 The OQ hazard library provided us with a broad range of
 well-tested, high performance, open source global GMPEs. Due to constraints
 imposed by the software architecture of earlier implementations of ShakeMap, the
 development and validation of GMPE modules is time consuming and difficult, which
-restricted the quantity and timeliness of the available modules. The oq-hazardlib
+restricted the quantity and timeliness of the available modules. The OQ Hazard Library
 provides a broad array of current GMPE and related hazard modules, as well as a
 framework for easily adding new modules (whether by GEM or ShakeMap staff),
 jumpstarting our efforts to re-implement ShakeMap.
 
-.. _OQ: www.globalquakemodel.org/openquake/about/
-.. _oq-hazardlib: github.com/gem/oq-hazardlib/
+.. _OQ: https://github.com/gem/oq-engine/#openquake-engine
+.. _openquake.hazardlib: http://docs.openquake.org/oq-engine/stable/openquake.hazardlib.html
 

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Dependencies
 
 - Mac OSX or Linux operating systems
 - Python 3
-- Python libraries: numpy, scipy, rasterio, fiona, xlrd, pandas, shapely, h5py, gdal, descartes, oq-hazlib, neicio,
+- Python libraries: numpy, scipy, rasterio, fiona, xlrd, pandas, shapely, h5py, gdal, descartes, openquake.engine, neicio,
   MapIO, matplotlib, jupyter, pytables, lxml
 
 OQ Hazard Library


### PR DESCRIPTION
Since OpenQuake Engine v2.5.0 we have merged the `oq-hazardlib` repo and its packages (pypi, Ubuntu, RHEL...) under `oq-engine` (see https://github.com/gem/oq-engine/blob/engine-2.5/doc/whats-new.md#release-notes-for-the-openquake-engine-version-25).

I have update links and the name of the pypi package containing hazarlib (`openquake.engine`)

Many thanks
Daniele