### PR TITLE
Improvements setup script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
     # Base requirements
 #    - conda config --set always_yes yes --set changeps1 no
 #    - conda info -a
-    - bash install-dependencies.sh -t
+    - bash install.sh -t
     - source activate shakelib2
     - conda list
 #    # Install shakelib

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 
 install:
     # Base requirements
+    - which conda
     - bash install.sh -t
     - echo $PATH
     - source activate shakelib2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ python:
 
 install:
     # Base requirements
-#    - conda config --set always_yes yes --set changeps1 no
-#    - conda info -a
     - bash install.sh -t
+    - echo $PATH
     - source activate shakelib2
+    - echo $PATH
     - export PATH="$HOME/miniconda/bin:$PATH"
     - echo $PATH
     - conda list

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,11 @@ python:
 
 install:
     # Base requirements
-    - which conda
     - bash install.sh -t
     - echo $PATH
+    - export PATH="$HOME/miniconda/bin:$PATH"
     - source activate shakelib2
     - echo $PATH
-    - export PATH="$HOME/miniconda/bin:$PATH"
     - echo $PATH
     - conda list
 #    # Install shakelib

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,15 @@
 language: python
 sudo: false
-#cache:
-#  directories:
-#  - /home/travis/miniconda/envs/
-#  - /home/travis/virtualenv/python3.5.2/lib/python3.5/site-packages
 python:
     - "3.5"
 
 install:
-    #------------------
     # Base requirements
-    #------------------
-#    - sudo apt-get update
-    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    - bash miniconda.sh -f -b -p $HOME/miniconda
-    - export PATH="$HOME/miniconda/bin:$PATH"
-    - conda config --set always_yes yes --set changeps1 no
-    - conda update -q conda
-    - conda info -a
-    - conda config --prepend channels conda-forge
-    - conda config --append channels digitalglobe # for rasterio v 1.0a9
-    - conda config --append channels ioos # for rasterio v 1.0a2
-    - bash setup_env.sh
+#    - conda config --set always_yes yes --set changeps1 no
+#    - conda info -a
+    - bash install-dependencies.sh -t
     - source activate shakelib2
-    #---------------------
     # Install shakelib
-    #---------------------
     - python setup.py install
 before_script:
     # This is to take care of Invalid DISPLAY variable
@@ -35,7 +19,6 @@ before_script:
 script:
     - export PYTHONPATH="."
     - py.test --cov=shakelib
-#    - echo `sphinx-build --version`
 
 after_success:
     - pip install codecov codacy-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 install:
     # Install shakelib and requirements
     - bash install.sh -t
+    - export PATH="$HOME/miniconda/bin:$PATH"
     - source activate shakelib2
 before_script:
     # This is to take care of Invalid DISPLAY variable

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
 #    - conda info -a
     - bash install.sh -t
     - source activate shakelib2
+    - export PATH="$HOME/miniconda/bin:$PATH"
     - echo $PATH
     - conda list
 #    # Install shakelib

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,9 @@ python:
     - "3.5"
 
 install:
-    # Base requirements
+    # Install shakelib and requirements
     - bash install.sh -t
-    - echo $PATH
-    - export PATH="$HOME/miniconda/bin:$PATH"
     - source activate shakelib2
-    - echo $PATH
-    - echo $PATH
-    - conda list
-#    # Install shakelib
-#    - python setup.py install
 before_script:
     # This is to take care of Invalid DISPLAY variable
     - "export DISPLAY=:99.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ install:
 #    - conda config --set always_yes yes --set changeps1 no
 #    - conda info -a
     - bash install-dependencies.sh -t
-    - conda list
     - source activate shakelib2
+    - conda list
     # Install shakelib
     - python setup.py install
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
 #    - conda info -a
     - bash install.sh -t
     - source activate shakelib2
+    - echo $PATH
     - conda list
 #    # Install shakelib
 #    - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
 #    - conda config --set always_yes yes --set changeps1 no
 #    - conda info -a
     - bash install-dependencies.sh -t
+    - conda list
     - source activate shakelib2
     # Install shakelib
     - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ install:
     - bash install-dependencies.sh -t
     - source activate shakelib2
     - conda list
-    # Install shakelib
-    - python setup.py install
+#    # Install shakelib
+#    - python setup.py install
 before_script:
     # This is to take care of Invalid DISPLAY variable
     - "export DISPLAY=:99.0"

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -37,6 +37,8 @@ if [ $travis == 0 ] ; then
     DEPARRAY+=(ipython=6.1.0 spyder=3.2.1-py35_0 jupyter=1.0.0 seaborn=0.8.0 sphinx=1.6.3)
 fi
 
+echo $DEPARRAY
+
 # Turn off whatever other virtual environment user might be in
 source deactivate
 

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -4,11 +4,37 @@ echo $PATH
 VENV=shakelib2
 PYVER=3.5
 
+# Is conda installed?
+conda=$(which condas)
+if [ ! "$conda" ] ; then
+    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    bash miniconda.sh -f -b -p $HOME/miniconda
+    export PATH="$HOME/miniconda/bin:$PATH"
+fi
+
+conda update -q conda
+conda config --prepend channels conda-forge
+conda config --append channels digitalglobe # for rasterio v 1.0a9
+conda config --append channels ioos # for rasterio v 1.0a2
+
 unamestr=`uname`
 if [[ "$unamestr" == 'Linux' ]]; then
     DEPARRAY=(numpy=1.11 scipy=0.19.1 matplotlib=2.0.2 rasterio=1.0a2 pandas=0.20.3 h5py=2.7.0 gdal=2.1.4 pytest=3.2.0 pytest-cov=2.5.1 cartopy=0.15.1 fiona=1.7.8 numexpr=2.6.2 configobj=5.0.6 decorator=4.1.2 versioneer==0.18)
 elif [[ "$unamestr" == 'FreeBSD' ]] || [[ "$unamestr" == 'Darwin' ]]; then
    DEPARRAY=(numpy=1.13.1 scipy=0.19.1 matplotlib=2.0.2 rasterio=1.0a9 pandas=0.20.3 h5py=2.7.0 gdal=2.1.4 pytest=3.2.0 pytest-cov=2.5.1 cartopy=0.15.1 fiona=1.7.8 numexpr=2.6.2 configobj=5.0.6 decorator=4.1.2 versioneer==0.18)
+fi
+
+# Additional deps, not not needed for Travis
+travis=0
+while getopts t FLAG; do
+  case $FLAG in
+    t)
+      travis=1
+      ;;
+  esac
+done
+if [ $travis == 0 ] ; then
+    DEPARRAY+=(ipython=6.1.0 spyder=3.2.1-py35_0 jupyter=1.0.0 seaborn=0.8.0 sphinx=1.6.3)
 fi
 
 # Turn off whatever other virtual environment user might be in

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -5,7 +5,7 @@ VENV=shakelib2
 PYVER=3.5
 
 # Is conda installed?
-conda=$(which condas)
+conda=$(which conda)
 if [ ! "$conda" ] ; then
     wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     bash miniconda.sh -f -b -p $HOME/miniconda

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -12,7 +12,7 @@ if [ ! "$conda" ] ; then
     export PATH="$HOME/miniconda/bin:$PATH"
 fi
 
-conda update -q conda
+conda update -q -y conda
 conda config --prepend channels conda-forge
 conda config --append channels digitalglobe # for rasterio v 1.0a9
 conda config --append channels ioos # for rasterio v 1.0a2
@@ -46,7 +46,7 @@ cd $HOME;
 conda remove --name $VENV --all -y
 cd $CWD
 
-conda create --name $VENV --yes python=$PYVER ${DEPARRAY[*]}
+conda create --name $VENV -y python=$PYVER ${DEPARRAY[*]}
 
 # Activate the new environment
 source activate $VENV

--- a/install.sh
+++ b/install.sh
@@ -63,12 +63,8 @@ echo ${DEPARRAY[*]}
 conda create --name $VENV -y python=$PYVER ${DEPARRAY[*]}
 
 # Activate the new environment
-conda info -e
-conda list
 echo "Activating the $VENV virtual environment"
 source activate $VENV
-conda info -e
-conda list
 
 # OpenQuake v2.5.0
 echo "Downloading OpenQuake v2.5.0..."
@@ -90,8 +86,3 @@ pip install -e .
 
 # Tell the user they have to activate this environment
 echo "Type 'source activate $VENV' to use this new virtual environment."
-
-echo "which conda:"
-which conda
-
-echo "which python"

--- a/install.sh
+++ b/install.sh
@@ -64,9 +64,11 @@ conda create --name $VENV -y python=$PYVER ${DEPARRAY[*]}
 
 # Activate the new environment
 conda info -e
+conda list
 echo "Activating the $VENV virtual environment"
 source activate $VENV
 conda info -e
+conda list
 
 # OpenQuake v2.5.0
 echo "Downloading OpenQuake v2.5.0..."

--- a/install.sh
+++ b/install.sh
@@ -92,3 +92,8 @@ fi
 
 # Tell the user they have to activate this environment
 echo "Type 'source activate $VENV' to use this new virtual environment."
+
+echo "which conda:"
+which conda
+
+echo "which python"

--- a/install.sh
+++ b/install.sh
@@ -86,9 +86,7 @@ pip -q install \
 
 # This package
 echo "Installing shakelib..."
-if [ $travis == 0 ] ; then
-    pip install -e .
-fi
+pip install -e .
 
 # Tell the user they have to activate this environment
 echo "Type 'source activate $VENV' to use this new virtual environment."

--- a/install.sh
+++ b/install.sh
@@ -57,14 +57,16 @@ conda remove --name $VENV --all -y
 cd $CWD
 
 # Create a conda virtual environment
-echo "Creating a conda virtual environment"
+echo "Creating the $VENV virtual environment"
 echo "with the following dependencies:"
 echo $DEPARRAY
 conda create --name $VENV -y python=$PYVER ${DEPARRAY[*]}
 
 # Activate the new environment
-echo "Activating the virtual environment"
+conda info -e
+echo "Activating the $VENV virtual environment"
 source activate $VENV
+conda info -e
 
 # OpenQuake v2.5.0
 echo "Downloading OpenQuake v2.5.0..."

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,8 @@ PYVER=3.5
 # Is conda installed?
 conda=$(which conda)
 if [ ! "$conda" ] ; then
-    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+        -O miniconda.sh;
     bash miniconda.sh -f -b -p $HOME/miniconda
     export PATH="$HOME/miniconda/bin:$PATH"
 fi
@@ -19,12 +20,18 @@ conda config --append channels ioos # for rasterio v 1.0a2
 
 unamestr=`uname`
 if [[ "$unamestr" == 'Linux' ]]; then
-    DEPARRAY=(numpy=1.11 scipy=0.19.1 matplotlib=2.0.2 rasterio=1.0a2 pandas=0.20.3 h5py=2.7.0 gdal=2.1.4 pytest=3.2.0 pytest-cov=2.5.1 cartopy=0.15.1 fiona=1.7.8 numexpr=2.6.2 configobj=5.0.6 decorator=4.1.2 versioneer==0.18)
+    DEPARRAY=(numpy=1.11 scipy=0.19.1 matplotlib=2.0.2 rasterio=1.0a2 \
+        pandas=0.20.3 h5py=2.7.0 gdal=2.1.4 pytest=3.2.0 pytest-cov=2.5.1 \
+        cartopy=0.15.1 fiona=1.7.8 numexpr=2.6.2 configobj=5.0.6 decorator=4.1.2 \
+        versioneer==0.18)
 elif [[ "$unamestr" == 'FreeBSD' ]] || [[ "$unamestr" == 'Darwin' ]]; then
-   DEPARRAY=(numpy=1.13.1 scipy=0.19.1 matplotlib=2.0.2 rasterio=1.0a9 pandas=0.20.3 h5py=2.7.0 gdal=2.1.4 pytest=3.2.0 pytest-cov=2.5.1 cartopy=0.15.1 fiona=1.7.8 numexpr=2.6.2 configobj=5.0.6 decorator=4.1.2 versioneer==0.18)
+    DEPARRAY=(numpy=1.13.1 scipy=0.19.1 matplotlib=2.0.2 rasterio=1.0a9 \
+        pandas=0.20.3 h5py=2.7.0 gdal=2.1.4 pytest=3.2.0 pytest-cov=2.5.1 \
+        cartopy=0.15.1 fiona=1.7.8 numexpr=2.6.2 configobj=5.0.6 decorator=4.1.2 \
+        versioneer==0.18)
 fi
 
-# Additional deps, not not needed for Travis
+# Is the Travis flag set?
 travis=0
 while getopts t FLAG; do
   case $FLAG in
@@ -33,8 +40,11 @@ while getopts t FLAG; do
       ;;
   esac
 done
+
+# Append additional deps that are not for Travis CI
 if [ $travis == 0 ] ; then
-    DEPARRAY+=(ipython=6.1.0 spyder=3.2.1-py35_0 jupyter=1.0.0 seaborn=0.8.0 sphinx=1.6.3)
+    DEPARRAY+=(ipython=6.1.0 spyder=3.2.1 jupyter=1.0.0 seaborn=0.8.0 \
+        sphinx=1.6.3)
 fi
 
 echo $DEPARRAY
@@ -54,13 +64,24 @@ conda create --name $VENV -y python=$PYVER ${DEPARRAY[*]}
 source activate $VENV
 
 # OpenQuake v2.5.0
-curl --max-time 60 --retry 3 -L https://github.com/gem/oq-engine/archive/v2.5.0.zip -o openquake.zip
+echo "Downloading OpenQuake v2.5.0..."
+curl --max-time 60 --retry 3 -L \
+    https://github.com/gem/oq-engine/archive/v2.5.0.zip -o openquake.zip
 pip -v install --no-deps openquake.zip
 rm openquake.zip
 
+# MapIO and impact-utils
+echo "Installing MapIO..."
 pip -v install https://github.com/usgs/MapIO/archive/master.zip
-pip -v install https://github.com/usgs/earthquake-impact-utils/archive/master.zip
+echo "Installing impact-utils..."
+pip -v install \
+    https://github.com/usgs/earthquake-impact-utils/archive/master.zip
 
+# This package
+echo "Installing shakelib..."
+if [ $travis == 0 ] ; then
+    pip install -e .
+fi
 
 # Tell the user they have to activate this environment
 echo "Type 'source activate $VENV' to use this new virtual environment."

--- a/install.sh
+++ b/install.sh
@@ -59,7 +59,7 @@ cd $CWD
 # Create a conda virtual environment
 echo "Creating the $VENV virtual environment"
 echo "with the following dependencies:"
-echo $DEPARRAY
+echo ${DEPARRAY[*]}
 conda create --name $VENV -y python=$PYVER ${DEPARRAY[*]}
 
 # Activate the new environment
@@ -77,9 +77,9 @@ rm openquake.zip
 
 # MapIO and impact-utils
 echo "Installing MapIO..."
-pip -v install https://github.com/usgs/MapIO/archive/master.zip
+pip -q install https://github.com/usgs/MapIO/archive/master.zip
 echo "Installing impact-utils..."
-pip -v install \
+pip -q install \
     https://github.com/usgs/earthquake-impact-utils/archive/master.zip
 
 # This package

--- a/install.sh
+++ b/install.sh
@@ -47,8 +47,6 @@ if [ $travis == 0 ] ; then
         sphinx=1.6.3)
 fi
 
-echo $DEPARRAY
-
 # Turn off whatever other virtual environment user might be in
 source deactivate
 
@@ -58,9 +56,14 @@ cd $HOME;
 conda remove --name $VENV --all -y
 cd $CWD
 
+# Create a conda virtual environment
+echo "Creating a conda virtual environment"
+echo "with the following dependencies:"
+echo $DEPARRAY
 conda create --name $VENV -y python=$PYVER ${DEPARRAY[*]}
 
 # Activate the new environment
+echo "Activating the virtual environment"
 source activate $VENV
 
 # OpenQuake v2.5.0

--- a/install.sh
+++ b/install.sh
@@ -67,7 +67,7 @@ source activate $VENV
 echo "Downloading OpenQuake v2.5.0..."
 curl --max-time 60 --retry 3 -L \
     https://github.com/gem/oq-engine/archive/v2.5.0.zip -o openquake.zip
-pip -v install --no-deps openquake.zip
+pip -q install --no-deps openquake.zip
 rm openquake.zip
 
 # MapIO and impact-utils


### PR DESCRIPTION
- Renamed setup_env.sh to install.sh. I decided against install-dependencies.sh because it is nice to have this script also install itself. 
- Detects conda and doesn't download/install if not needed (usually for existing environments that already have miniconda or anaconda)
- Added option ("-t") to install.sh that suppresses dependencies that are not needed on Travis, but are useful for shakemap developers/users. Also installs this package now.  
- Moves as much as possible from .travis.yml into install-dependencies.sh