### PR TITLE
Quads

### DIFF
--- a/shakelib/rupture/edge_rupture.py
+++ b/shakelib/rupture/edge_rupture.py
@@ -77,7 +77,7 @@ class EdgeRupture(Rupture):
             group_index.extend([g_ind] * n_pairs)
             g_ind = g_ind + 1
 
-        reference = d['features'][0]['properties']['reference']
+        reference = d['metadata']['reference']
 
         # Add origin information to metadata
         odict = origin.__dict__
@@ -154,12 +154,13 @@ class EdgeRupture(Rupture):
             coords.append(poly)
 
         d = {"type": "FeatureCollection",
-             "metadata": {},
+             "metadata": {
+                 "reference": reference
+             },
              "features": [{
                  "type": "Feature",
                  "properties": {
-                     "rupture type": "rupture extent",
-                     "reference": reference,
+                     "rupture type": "rupture extent"
                  },
                  "geometry": {
                      "type": "MultiPolygon",

--- a/shakelib/rupture/factory.py
+++ b/shakelib/rupture/factory.py
@@ -300,7 +300,7 @@ def validate_json(d):
                 # -------------------------------------------------------------
                 top_depth = p[j][2]
                 bot_depth = p[-(j + 2)][2]
-                if top_depth > bot_depth:
+                if top_depth >= bot_depth:
                     raise Exception(
                         'Top points must be ordered before bottom points.')
 

--- a/shakelib/rupture/factory.py
+++ b/shakelib/rupture/factory.py
@@ -127,20 +127,6 @@ def rupture_from_dict(d):
     """
     validate_json(d)
 
-    # Construct an origin
-#    origin = Origin({
-#        'lat': d['metadata']['lat'],
-#        'lon': d['metadata']['lon'],
-#        'depth': d['metadata']['depth'],
-#        'mag': d['metadata']['mag'],
-#        'eventsourcecode': d['metadata']['eventsourcecode'],
-#        'time': d['metadata']['time'],
-#        'eventsource': d['metadata']['eventsource'],
-#        'locstring': d['metadata']['locstring'],
-#        'rake': d['metadata']['rake'],
-#        'mech': d['metadata']['mech'],
-#        'created': d['metadata']['created']
-#    })
     origin = Origin(d['metadata'])
 
     # What type of rupture is this?
@@ -342,28 +328,26 @@ def is_quadrupture_class(d):
         p = polygons[i]
         n_points = len(p)
         n_pairs = int((n_points - 1) / 2)
-
-        # Within each polygon, top and bottom edges must be horizontal
-        depths = [pt[2] for pt in p]
-        tops = np.array(depths[0:n_pairs])
-        if not np.isclose(tops[0], tops, rtol=0,
-                          atol=constants.DEPTH_TOL).all():
-            isQuad = False
-        bots = np.array(depths[(n_pairs):-1])
-        if not np.isclose(bots[0], bots, rtol=0,
-                          atol=constants.DEPTH_TOL).all():
-            isQuad = False
-
         n_quads = n_pairs - 1
-        for j in range(n_quads):
-            # Four points of each quad should be co-planar within a tolerance
-            quad = [Point(p[j][0], p[j][1], p[j][2]),
-                    Point(p[j + 1][0], p[j + 1][1], p[j + 1][2]),
-                    Point(p[-(j + 3)][0], p[-(j + 3)][1], p[-(j + 3)][2]),
-                    Point(p[-(j + 2)][0], p[-(j + 2)][1], p[-(j + 2)][2])]
 
+        for k in range(n_quads):
+            # Four points of each quad should be co-planar within a tolerance
+            quad = [Point(p[k][0], p[k][1], p[k][2]),
+                    Point(p[k + 1][0], p[k + 1][1], p[k + 1][2]),
+                    Point(p[-(k + 3)][0], p[-(k + 3)][1], p[-(k + 3)][2]),
+                    Point(p[-(k + 2)][0], p[-(k + 2)][1], p[-(k + 2)][2])]
             test = utils.is_quad(quad)
             if test[0] is False:
+                isQuad = False
+
+            # Within each quad, top and bottom edges must be horizontal
+            tops = np.array([quad[0].depth, quad[1].depth])
+            if not np.isclose(tops[0], tops, rtol=0,
+                              atol=constants.DEPTH_TOL).all():
+                isQuad = False
+            bots = np.array([quad[2].depth, quad[3].depth])
+            if not np.isclose(bots[0], bots, rtol=0,
+                              atol=constants.DEPTH_TOL).all():
                 isQuad = False
 
     return isQuad

--- a/shakelib/rupture/factory.py
+++ b/shakelib/rupture/factory.py
@@ -111,7 +111,7 @@ def rupture_from_dict_and_origin(d, origin, mesh_dx=0.5):
 
 def rupture_from_dict(d):
     """
-    Method returns either a Rupture subclass (QuadRupture, EdgeRupture, or 
+    Method returns either a Rupture subclass (QuadRupture, EdgeRupture, or
     PointRupture) object based on a GeoJSON dictionary.
 
     .. seealso::
@@ -233,13 +233,14 @@ def text_to_json(file):
 
     d = {
         "type": "FeatureCollection",
-        "metadata": {},
+        "metadata": {
+            'reference':reference
+        },
         "features": [
             {
                 "type": "Feature",
                 "properties": {
-                    "rupture type": "rupture extent",
-                    "reference": reference
+                    "rupture type": "rupture extent"
                 },
                 "geometry": {
                     "type": "MultiPolygon",
@@ -265,11 +266,11 @@ def validate_json(d):
     if len(d['features']) != 1:
         raise Exception('JSON file should contain excactly one feature.')
 
-    f = d['features'][0]
+    if 'reference' not in d['metadata'].keys():
+        raise Exception('Json metadata field should contain '
+                        '\"reference\" key.')
 
-    if 'reference' not in f['properties'].keys():
-        raise Exception('Feature property dictionary should contain '
-                        '\"referencey\" key.')
+    f = d['features'][0]
 
     if f['type'] != 'Feature':
         raise Exception('Feature type should be \"Feature\".')

--- a/shakelib/rupture/point_rupture.py
+++ b/shakelib/rupture/point_rupture.py
@@ -24,13 +24,14 @@ class PointRupture(Rupture):
         - Provide reasonable default values for rupture parameters.
     """
 
-    def __init__(self, origin, reference=""):
+    def __init__(self, origin, reference="Origin"):
         """
         Constructs a PointRupture instance.
 
         Args:
             origin (Origin): Reference to a ShakeMap Origin instance.
-            reference (str): Citable reference for rupture.
+            reference (str): Citable reference for rupture; in the case of a
+                PointRupture, the 'reference' is probably the origin.
 
         Returns:
             PointRupture instance.
@@ -41,12 +42,13 @@ class PointRupture(Rupture):
         coords = [origin.lon, origin.lat, origin.depth]
 
         d = {"type": "FeatureCollection",
-             "metadata": {},
+             "metadata": {
+                 "reference": reference
+             },
              "features": [{
                  "type": "Feature",
                  "properties": {
-                     "rupture type": "rupture extent",
-                     "reference": reference,
+                     "rupture type": "rupture extent"
                  },
                  "geometry": {
                      "type": "Point",

--- a/shakelib/rupture/quad_rupture.py
+++ b/shakelib/rupture/quad_rupture.py
@@ -68,7 +68,7 @@ class QuadRupture(Rupture):
         self._lat = lat
         self._depth = dep
         self._origin = origin
-        self._reference = d['features'][0]['properties']['reference']
+        self._reference = d['metadata']['reference']
         self._setQuadrilaterals()
 
     def getDepthAtPoint(self, lat, lon):
@@ -360,12 +360,13 @@ class QuadRupture(Rupture):
             coords.append(poly)
 
         d = {"type": "FeatureCollection",
-             "metadata": {},
+             "metadata": {
+                 "reference": reference
+             },
              "features": [{
                  "type": "Feature",
                  "properties": {
-                     "rupture type": "rupture extent",
-                     "reference": reference,
+                     "rupture type": "rupture extent"
                  },
                  "geometry": {
                      "type": "MultiPolygon",
@@ -525,12 +526,13 @@ class QuadRupture(Rupture):
             coords.append(poly)
 
         d = {"type": "FeatureCollection",
-             "metadata": {},
+             "metadata": {
+                 "reference": reference
+             },
              "features": [{
                  "type": "Feature",
                  "properties": {
-                     "rupture type": "rupture extent",
-                     "reference": reference,
+                     "rupture type": "rupture extent"
                  },
                  "geometry": {
                      "type": "MultiPolygon",

--- a/tests/rupture_data/cascadia.json
+++ b/tests/rupture_data/cascadia.json
@@ -3,14 +3,14 @@
     "metadata": {
         "eventtime": "",
         "eventid": "",
-        "title": "Cascadia Megathrust"
+        "title": "Cascadia Megathrust",
+	"reference": "NSHMP14 file sub0_ch_mid.in"
     },
     "features":[
         {
             "type": "Feature",
             "properties": {
-                "rupture type": "rupture extent",
-		"reference": "NSHMP14 file sub0_ch_mid.in"
+                "rupture type": "rupture extent"
             },
             "geometry": {
 	        "type": "MultiPolygon",

--- a/tests/rupture_data/izmit.json
+++ b/tests/rupture_data/izmit.json
@@ -3,12 +3,12 @@
       "magnitude": 7.4,
       "eventtime": "1999-08-17T00:01:39Z",
       "eventid": "usp0009d4z",
-      "title": "1999 Izmit Earthquake"
+      "title": "1999 Izmit Earthquake",
+      "reference": "Barka, A., H. S. Akyz, E. Altunel, G. Sunal, Z. Akir, A. Dikbas, B. Yerli, R. Armijo, B. Meyer, J. B. d. Chabalier, T. Rockwell, J. R. Dolan, R. Hartleb, T. Dawson, S. Christofferson, A. Tucker, T. Fumal, R. Langridge, H. Stenner, W. Lettis, J. Bachhuber, and W. Page (2002). The Surface Rupture and Slip Distribution of the 17 August 1999 Izmit Earthquake (M 7.4), North Anatolian Fault, Bull. Seism. Soc. Am. 92, 43-60."
   },
   "features":[
       { "type": "Feature",
-        "properties": {"rupture type": "rupture extent",
-		       "reference": "Barka, A., H. S. Akyz, E. Altunel, G. Sunal, Z. Akir, A. Dikbas, B. Yerli, R. Armijo, B. Meyer, J. B. d. Chabalier, T. Rockwell, J. R. Dolan, R. Hartleb, T. Dawson, S. Christofferson, A. Tucker, T. Fumal, R. Langridge, H. Stenner, W. Lettis, J. Bachhuber, and W. Page (2002). The Surface Rupture and Slip Distribution of the 17 August 1999 Izmit Earthquake (M 7.4), North Anatolian Fault, Bull. Seism. Soc. Am. 92, 43-60."},
+        "properties": {"rupture type": "rupture extent" },
         "geometry": {
 	    "type": "MultiPolygon",
 	    "coordinates":[[

--- a/tests/rupture_test.py
+++ b/tests/rupture_test.py
@@ -28,7 +28,6 @@ homedir = os.path.dirname(os.path.abspath(__file__))  # where is this script?
 shakedir = os.path.abspath(os.path.join(homedir, '..', '..'))
 sys.path.insert(0, shakedir)
 
-homedir='/Users/emthompson/src/python/shakelib/tests/'
 
 def test_rupture_from_dict():
     # Grab an EdgeRupture

--- a/tests/rupture_test.py
+++ b/tests/rupture_test.py
@@ -28,6 +28,7 @@ homedir = os.path.dirname(os.path.abspath(__file__))  # where is this script?
 shakedir = os.path.abspath(os.path.join(homedir, '..', '..'))
 sys.path.insert(0, shakedir)
 
+homedir='/Users/emthompson/src/python/shakelib/tests/'
 
 def test_rupture_from_dict():
     # Grab an EdgeRupture


### PR DESCRIPTION
This PR does two things:
- Puts rupture reference in the JSON metadata dictionary rather than the feature properties, which is must more sensible. 
- Improves the checks for whether or not a rupture can be treated as QuadRupture

I was looking at this because Mike found that the rupture for [this event](https://earthquake.usgs.gov/earthquakes/eventpage/usc000nzvd#shakemap) ended up as an EdgeRupture. It clearly SHOULD be able to be treated as a QuadRupture, but the vertices do not follow the assumed Shakemap rupture convention, and thus this problem is not really solved by this PR. My question going forward is: Should we try to accommodate files like this or be strict about how the ruptures can be specified? 